### PR TITLE
Feature/sys admin management

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,39 @@ We use the next roles:
 
  - [postgresql](https://galaxy.ansible.com/geerlingguy/postgresql/) v1.3.1
 
+# Playbooks
+
+# Sys Admins `playbooks/sys_admins.yml`
+
+This playbook manages the sysadmin users.
+
+**Need user with `sudo` access without password**
+
+Add your `sys_admins` list in your `inventory/hosy_vars/` file.
+
+`sys_admins` is a list of maps. Need tree keys: `name`, `ssh_key` and `state`:
+
+```YAML
+# ./inventory/host_vars/local.tryton.org/config.yml
+...
+
+sys_admins:
+  - name: tryton
+    ssh_key: "~/.ssh/id_rsa.pub"
+    state: present
+  - name: "{{ development_user }}"
+    ssh_key: "~/.ssh/id_rsa.pub"
+    state: present
+
+...
+```
+
+To execute the playbook run:
+```
+> ansible-playbook playbooks/sys_admins.yml -u root --limit=dev -v
+```
+Change `root` for your user.
+
 ## Usage example
 
 Configure your hosts and group vars:
@@ -57,10 +90,6 @@ You can use lxc-scripts to create it:
 ```sh
 lxc-scripts/lxc-create.sh -n tryton-test -h local.tryton.org
 ```
-
-## Release History
-
-## Meta
 
 ## Contributing
 

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -1,7 +1,5 @@
 ---
-
-# User name and password for running ansible on host
-user: ubuntu
+development_user: "{{ lookup('env', 'USER') }}"
 
 repository: https://hg.tryton.org/trytond
 branch: 3.8

--- a/inventory/host_vars/local.tryton.org/config.yml
+++ b/inventory/host_vars/local.tryton.org/config.yml
@@ -1,1 +1,10 @@
 ---
+development_user: "{{ lookup('env', 'USER') }}"
+
+sys_admins:
+  - name: tryton
+    ssh_key: "~/.ssh/id_rsa.pub"
+    state: present
+  - name: "{{ development_user }}"
+    ssh_key: "~/.ssh/id_rsa.pub"
+    state: present

--- a/inventory/host_vars/local.tryton.org/config.yml
+++ b/inventory/host_vars/local.tryton.org/config.yml
@@ -1,6 +1,4 @@
 ---
-development_user: "{{ lookup('env', 'USER') }}"
-
 sys_admins:
   - name: tryton
     ssh_key: "~/.ssh/id_rsa.pub"

--- a/roles/common/templates/tryton.service.j2
+++ b/roles/common/templates/tryton.service.j2
@@ -7,5 +7,5 @@ Description=Tryton server
 ExecStart={{ venv_path }}/bin/python {{ ansible_env.HOME }}/trytond/bin/trytond -c {{ ansible_env.HOME }}/tryton.conf -d tryton-db
 
 # Execute service like user
-User={{ user }}
-Group={{ user }}
+User={{ development_user }}
+Group={{ development_user }}


### PR DESCRIPTION
Add `sys_admin` strategy used in [odoocoop](https://gitlab.com/femprocomuns/odoo-provisioning/) and in [timeoverflow](https://github.com/coopdevs/timeoverflow-provisioning) projects.