### PR TITLE
Use become only in 'Add ppa repository'

### DIFF
--- a/roles/common/tasks/install_java.yml
+++ b/roles/common/tasks/install_java.yml
@@ -5,7 +5,8 @@
     state: present
 
 - name: Add ppa repository
-  command: sudo add-apt-repository ppa:openjdk-r/ppa
+  command: add-apt-repository ppa:openjdk-r/ppa
+  become: yes
 
 - name: Run the equivalent of "apt-get update" as a separate step
   apt:

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,7 +1,6 @@
 ---
 - include: install_packages.yml
 - include: install_java.yml
-  become: yes
 - name: install postgres
   become: yes
   include_role:


### PR DESCRIPTION
Fix warning in `install_java/add_ppa_repository` task.
```
TASK [common : Add ppa repository] **************************************************************************************
 [WARNING]: Consider using 'become', 'become_method', and 'become_user' rather than running sudo
```